### PR TITLE
feat: 12-hour AM/PM time format on idle screen

### DIFF
--- a/display.py
+++ b/display.py
@@ -227,13 +227,13 @@ def _read_battery() -> tuple[int | None, str | None]:
 
 _SPX = 8  # each "pixel" is an 8×8 block → 30×30 logical grid on 240×240
 
-_C_BODY = (255, 146, 171)
-_C_HIGHLIGHT = (255, 190, 205)
-_C_OUTLINE = (140, 55, 80)
-_C_FOOT = (178, 42, 65)
+_C_BODY = (255, 165, 0)
+_C_HIGHLIGHT = (255, 200, 80)
+_C_OUTLINE = (140, 80, 0)
+_C_FOOT = (200, 100, 0)
 _C_EYE = (20, 20, 80)
 _C_SPARKLE = (255, 255, 255)
-_C_CHEEK = (255, 95, 130)
+_C_CHEEK = (255, 120, 0)
 _C_MOUTH_INT = (20, 20, 30)
 _C_MOUTH_EDGE = (180, 50, 80)
 
@@ -718,7 +718,7 @@ class Display:
         now = datetime.now()
 
         # Large clock
-        time_str = now.strftime("%H:%M")
+        time_str = now.strftime("%I:%M %p").lstrip("0")
         tw = self._clock_font.getlength(time_str)
         tx = int((self._width - tw) / 2)
         ty = int(self._height * 0.22)

--- a/display.py
+++ b/display.py
@@ -227,13 +227,13 @@ def _read_battery() -> tuple[int | None, str | None]:
 
 _SPX = 8  # each "pixel" is an 8×8 block → 30×30 logical grid on 240×240
 
-_C_BODY = (255, 165, 0)
-_C_HIGHLIGHT = (255, 200, 80)
-_C_OUTLINE = (140, 80, 0)
-_C_FOOT = (200, 100, 0)
+_C_BODY = (255, 146, 171)
+_C_HIGHLIGHT = (255, 190, 205)
+_C_OUTLINE = (140, 55, 80)
+_C_FOOT = (178, 42, 65)
 _C_EYE = (20, 20, 80)
 _C_SPARKLE = (255, 255, 255)
-_C_CHEEK = (255, 120, 0)
+_C_CHEEK = (255, 95, 130)
 _C_MOUTH_INT = (20, 20, 30)
 _C_MOUTH_EDGE = (180, 50, 80)
 


### PR DESCRIPTION
Small change to the idle screen clock -- switches from 24-hour military time (`%H:%M`) to 12-hour AM/PM format (`%I:%M %p`) with leading zero stripped.

**Before:** `14:30`
**After:** `2:30 PM`

One-line change in `display.py`. No config flags affected, no dependencies changed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that affects only how the idle clock string is formatted and rendered, with no impact on data handling or control flow.
> 
> **Overview**
> The idle screen clock display in `display.py` is switched from 24-hour time (`%H:%M`) to a 12-hour format with AM/PM (`%I:%M %p`) and the leading zero removed (e.g., `02:30 PM` → `2:30 PM`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dc5017c397386df067068705c4a1544b1f9290f4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->